### PR TITLE
add a command to unarchive some of the loaded products

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,8 +31,8 @@
 FROM openjdk:11-slim
 
 # Set following arguments with compatible versions
-ARG harvest_version=3.6.0-SNAPSHOT
-ARG reg_manager_version=4.4.0-SNAPSHOT
+ARG harvest_version=3.7.0-SNAPSHOT
+ARG reg_manager_version=4.5.0-SNAPSHOT
 ARG test_data_url=https://pds-gamma.jpl.nasa.gov/data/pds4/test-data/registry/urn-nasa-pds-insight_rad.tar.gz
 
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -61,4 +61,5 @@ registry-manager load-data -dir /tmp/harvest/out/ -es "$ES_URL" -force -auth /et
 if [ "$RUN_TESTS" = "true" ]; then
   echo "Setting archive status ..." 1>&2
   registry-manager set-archive-status -status archived -lidvid "$TEST_DATA_LIDVID" -es "$ES_URL" -auth /etc/es-auth.cfg
+  registry-manager set-archive-status -status staged -lidvid "urn:nasa:pds:insight_rad:data_calibrated::7.0" -es "$ES_URL" -auth /etc/es-auth.cfg
 fi


### PR DESCRIPTION
## 🗒️ Summary
Add a command in docker's entrypoint so that not all products are in status 'archived'

This is required for integration tests to work.


