### PR TITLE
update harvest and registry-mgr version to latest snapshots

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,8 +31,8 @@
 FROM openjdk:11-slim
 
 # Set following arguments with compatible versions
-ARG harvest_version=3.7.4
-ARG reg_manager_version=4.5.4
+ARG harvest_version=3.8.0-SNAPSHOT
+ARG reg_manager_version=4.6.0-SNAPSHOT
 ARG test_data_url=https://pds-gamma.jpl.nasa.gov/data/pds4/test-data/registry/urn-nasa-pds-insight_rad.tar.gz
 
 


### PR DESCRIPTION
## 🗒️ Summary
'nuf said

The registry-mgr update in particular adds support for provenance (`superseded_by`) metadata