### PR TITLE
Update secrets detection to detect-secrets==1.5.0 and add CLAUDE.md

### DIFF
--- a/.github/workflows/secrets-detection.yaml
+++ b/.github/workflows/secrets-detection.yaml
@@ -17,7 +17,7 @@ jobs:
             -
                 name: Install necessary packages
                 run: |
-                    pip install git+https://github.com/NASA-AMMOS/slim-detect-secrets.git@exp
+                    pip install detect-secrets==1.5.0
                     pip install jq
               
             -
@@ -44,7 +44,7 @@ jobs:
                     cp .secrets.baseline .secrets.new
 
                     # find the secrets in the repository
-                    detect-secrets scan --disable-plugin AbsolutePathDetectorExperimental --baseline .secrets.new \
+                    detect-secrets scan --baseline .secrets.new \
                         --exclude-files '\.secrets..*' \
                         --exclude-files '\.pre-commit-config\.yaml' \
                         --exclude-files '\.git.*' \

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,17 +1,11 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
-    {
-      "name": "AbsolutePathDetectorExperimental"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
       "name": "AWSKeyDetector"
-    },
-    {
-      "name": "AWSSensitiveInfoDetectorExperimental"
     },
     {
       "name": "AzureStorageKeyDetector"
@@ -30,10 +24,10 @@
       "name": "DiscordBotTokenDetector"
     },
     {
-      "name": "EmailAddressDetector"
+      "name": "GitHubTokenDetector"
     },
     {
-      "name": "GitHubTokenDetector"
+      "name": "GitLabTokenDetector"
     },
     {
       "name": "HexHighEntropyString",
@@ -62,7 +56,13 @@
       "name": "NpmDetector"
     },
     {
+      "name": "OpenAIDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -78,6 +78,9 @@
     },
     {
       "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
     },
     {
       "name": "TwilioKeyDetector"
@@ -139,36 +142,6 @@
     }
   ],
   "results": {
-    "common/pom.xml": [
-      {
-        "type": "Email Address",
-        "filename": "common/pom.xml",
-        "hashed_secret": "fac2dea9e49a83a2d6ee38c580d1e5358b45efa5",
-        "is_verified": false,
-        "line_number": 198,
-        "is_secret": false
-      }
-    ],
-    "harvest/pom.xml": [
-      {
-        "type": "Email Address",
-        "filename": "harvest/pom.xml",
-        "hashed_secret": "fac2dea9e49a83a2d6ee38c580d1e5358b45efa5",
-        "is_verified": false,
-        "line_number": 64,
-        "is_secret": false
-      }
-    ],
-    "manager/pom.xml": [
-      {
-        "type": "Email Address",
-        "filename": "manager/pom.xml",
-        "hashed_secret": "fac2dea9e49a83a2d6ee38c580d1e5358b45efa5",
-        "is_verified": false,
-        "line_number": 210,
-        "is_secret": false
-      }
-    ],
     "src/test/resources/es-auth.cfg": [
       {
         "type": "Secret Keyword",
@@ -180,5 +153,5 @@
       }
     ]
   },
-  "generated_at": "2025-10-21T17:00:05Z"
+  "generated_at": "2026-04-22T18:50:50Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Maven monorepo containing the PDS (Planetary Data System) Registry Loader tools — utilities for creating and populating the PDS Registry (backed by OpenSearch/Elasticsearch).
+
+**Key characteristics:**
+- Maven multi-module Java project (modules: `common`, `harvest`, `manager`)
+- Parent version: 1.3.0-SNAPSHOT
+- Depends on `registry-common` library for shared OpenSearch/Elasticsearch abstractions
+
+## Modules
+
+- **`common`** — Shared library code used by `harvest` and `manager`
+- **`harvest`** — Harvest tool: crawls PDS4 label files and loads product metadata into the registry
+- **`manager`** — Registry Manager tool: manages registry lifecycle (create, delete, load data dictionaries, set archive status, etc.)
+
+## Build Commands
+
+```bash
+# Build all modules
+mvn clean install
+
+# Build without tests
+mvn clean install -DskipTests
+
+# Build a single module (e.g., harvest)
+mvn clean install -pl harvest -am
+
+# Run tests
+mvn test
+
+# Package JARs
+mvn package
+```
+
+## Code Architecture
+
+### Harvest (`harvest/`)
+
+Entry point: `gov.nasa.pds.harvest.HarvestMain`
+
+Key classes:
+- `HarvestCmd` — main harvest command, reads config and drives crawling
+- `ProductProcessor` — processes individual PDS4 label files into registry documents
+- `LidVidCache` — tracks already-processed LIDVIDs to avoid duplicates
+- `WriterManager` / `SupplementalWriter` — manages output writers for different product types
+
+### Registry Manager (`manager/`)
+
+Entry point: `gov.nasa.pds.registry.mgr.RegistryManagerCli`
+
+Command groups:
+- `reg/` — registry lifecycle commands (create, delete, fetch, list known registries)
+- `dd/` — data dictionary commands (load, export, upgrade, delete LDDs)
+
+### Common (`common/`)
+
+Shared utilities used across harvest and manager: XML handling, connection utilities, etc.
+
+## Development Notes
+
+**Testing:**
+- Tests are in `src/test/java/` within each module
+- `tt/` packages contain technical/integration tests that require a live OpenSearch/Elasticsearch instance
+- Run unit tests with `mvn test`; integration tests require additional setup
+
+**Connection configuration:**
+- OpenSearch connection details are configured via config files passed to CLI commands
+- Auth config example at `manager/src/main/resources/auth/auth.cfg`
+
+**Pre-commit hooks:**
+- Secret detection using `detect-secrets`
+- Run `pre-commit install` to enable hooks locally
+- Baseline files: `.secrets.baseline` (root), plus one per submodule
+
+**CI/CD:**
+- Unstable builds (main branch): `.github/workflows/unstable-cicd.yaml`
+- Stable builds (releases): `.github/workflows/stable-cicd.yaml`
+- Secrets workflow: `.github/workflows/secrets-detection.yaml`

--- a/common/.secrets.baseline
+++ b/common/.secrets.baseline
@@ -1,14 +1,11 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
     },
     {
       "name": "AWSKeyDetector"
-    },
-    {
-      "name": "AWSSensitiveInfoDetectorExperimental"
     },
     {
       "name": "AzureStorageKeyDetector"
@@ -27,10 +24,10 @@
       "name": "DiscordBotTokenDetector"
     },
     {
-      "name": "EmailAddressDetector"
+      "name": "GitHubTokenDetector"
     },
     {
-      "name": "GitHubTokenDetector"
+      "name": "GitLabTokenDetector"
     },
     {
       "name": "HexHighEntropyString",
@@ -59,7 +56,13 @@
       "name": "NpmDetector"
     },
     {
+      "name": "OpenAIDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -75,6 +78,9 @@
     },
     {
       "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
     },
     {
       "name": "TwilioKeyDetector"
@@ -122,23 +128,19 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "\\.secrets..*",
         "\\.git.*",
         "\\.pre-commit-config\\.yaml",
-        "target"
+        "\\.secrets..*",
+        "target",
+        ".*\\.tfstate",
+        ".*\\.tfstate.*",
+        ".*\\.tfvars",
+        ".*\\.terraform",
+        ".*\\.terraformrc",
+        ".*\\terraform.rc"
       ]
     }
   ],
-  "results": {
-    "pom.xml": [
-      {
-        "type": "Email Address",
-        "filename": "pom.xml",
-        "hashed_secret": "fac2dea9e49a83a2d6ee38c580d1e5358b45efa5",
-        "is_verified": false,
-        "line_number": 189
-      }
-    ]
-  },
-  "generated_at": "2025-06-19T20:00:34Z"
+  "results": {},
+  "generated_at": "2026-04-22T18:50:50Z"
 }

--- a/harvest/.secrets.baseline
+++ b/harvest/.secrets.baseline
@@ -1,14 +1,11 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
     },
     {
       "name": "AWSKeyDetector"
-    },
-    {
-      "name": "AWSSensitiveInfoDetectorExperimental"
     },
     {
       "name": "AzureStorageKeyDetector"
@@ -27,10 +24,10 @@
       "name": "DiscordBotTokenDetector"
     },
     {
-      "name": "EmailAddressDetector"
+      "name": "GitHubTokenDetector"
     },
     {
-      "name": "GitHubTokenDetector"
+      "name": "GitLabTokenDetector"
     },
     {
       "name": "HexHighEntropyString",
@@ -59,7 +56,13 @@
       "name": "NpmDetector"
     },
     {
+      "name": "OpenAIDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -75,6 +78,9 @@
     },
     {
       "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
     },
     {
       "name": "TwilioKeyDetector"
@@ -118,23 +124,19 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "\\.secrets..*",
         "\\.git.*",
         "\\.pre-commit-config\\.yaml",
-        "target"
+        "\\.secrets..*",
+        "target",
+        ".*\\.tfstate",
+        ".*\\.tfstate.*",
+        ".*\\.tfvars",
+        ".*\\.terraform",
+        ".*\\.terraformrc",
+        ".*\\terraform.rc"
       ]
     }
   ],
-  "results": {
-    "pom.xml": [
-      {
-        "type": "Email Address",
-        "filename": "pom.xml",
-        "hashed_secret": "fac2dea9e49a83a2d6ee38c580d1e5358b45efa5",
-        "is_verified": false,
-        "line_number": 65
-      }
-    ]
-  },
-  "generated_at": "2024-02-08T17:03:16Z"
+  "results": {},
+  "generated_at": "2026-04-22T18:50:50Z"
 }

--- a/manager/.secrets.baseline
+++ b/manager/.secrets.baseline
@@ -1,14 +1,11 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
     },
     {
       "name": "AWSKeyDetector"
-    },
-    {
-      "name": "AWSSensitiveInfoDetectorExperimental"
     },
     {
       "name": "AzureStorageKeyDetector"
@@ -27,10 +24,10 @@
       "name": "DiscordBotTokenDetector"
     },
     {
-      "name": "EmailAddressDetector"
+      "name": "GitHubTokenDetector"
     },
     {
-      "name": "GitHubTokenDetector"
+      "name": "GitLabTokenDetector"
     },
     {
       "name": "HexHighEntropyString",
@@ -59,7 +56,13 @@
       "name": "NpmDetector"
     },
     {
+      "name": "OpenAIDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -75,6 +78,9 @@
     },
     {
       "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
     },
     {
       "name": "TwilioKeyDetector"
@@ -122,32 +128,30 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "\\.secrets..*",
         "\\.git.*",
         "\\.pre-commit-config\\.yaml",
-        "target"
+        "\\.secrets..*",
+        "target",
+        ".*\\.tfstate",
+        ".*\\.tfstate.*",
+        ".*\\.tfvars",
+        ".*\\.terraform",
+        ".*\\.terraformrc",
+        ".*\\terraform.rc"
       ]
     }
   ],
   "results": {
-    "pom.xml": [
-      {
-        "type": "Email Address",
-        "filename": "pom.xml",
-        "hashed_secret": "fac2dea9e49a83a2d6ee38c580d1e5358b45efa5",
-        "is_verified": false,
-        "line_number": 223
-      }
-    ],
     "src/main/resources/auth/auth.cfg": [
       {
         "type": "Secret Keyword",
         "filename": "src/main/resources/auth/auth.cfg",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 3
+        "line_number": 3,
+        "is_secret": false
       }
     ]
   },
-  "generated_at": "2025-06-19T19:54:52Z"
+  "generated_at": "2026-04-22T18:50:50Z"
 }


### PR DESCRIPTION
## 🗒️ Summary

Sister PR to NASA-PDS/registry-common#246, applying the same secrets-detection and CLAUDE.md updates to this repo.

- **`secrets-detection.yaml`**: replaces `slim-detect-secrets@exp` with `detect-secrets==1.5.0`; removes `--disable-plugin AbsolutePathDetectorExperimental` (that plugin no longer exists in 1.5.0)
- **`.secrets.baseline`** (root + all submodule baselines): updated to v1.5.0 format — removes experimental plugins (`AWSSensitiveInfoDetectorExperimental`, `EmailAddressDetector`), adds `GitLabTokenDetector`, `OpenAIDetector`, `PypiTokenDetector`, `TelegramBotTokenDetector`, and adds terraform file exclusion patterns to submodule baselines
- **`CLAUDE.md`**: new file providing project overview, build commands, module descriptions, and development notes for Claude Code

> 🤖 This PR was developed with AI assistance (Claude Sonnet 4.6, ~90% AI-influenced).

## ⚙️ Test Data and/or Report

No functional code changes — CI will validate the updated secrets workflow on merge.

## ♻️ Related Issues

Refs NASA-PDS/registry-common#246