### PR TITLE
Resolve ops: field types from built-in map; add missing harvest_version; add -f/--force flag; fix force mode losing found field types

### DIFF
--- a/common/src/main/java/gov/nasa/pds/registry/common/connection/aws/MGetRespWrap.java
+++ b/common/src/main/java/gov/nasa/pds/registry/common/connection/aws/MGetRespWrap.java
@@ -17,7 +17,7 @@ class MGetRespWrap extends GetRespWrap {
   }
   @Override
   public List<Tuple> dataTypes() throws IOException, DataTypeNotFoundException {
-    boolean stillMissing = false;
+    ArrayList<String> missing = new ArrayList<String>();
     ArrayList<Tuple> results = new ArrayList<Tuple>();
     for (MultiGetResponseItem<Object> doc : this.parent.docs()) {
       Tuple t = null;
@@ -32,13 +32,12 @@ class MGetRespWrap extends GetRespWrap {
             log.warn("Could not find datatype for field {} and defaulting to 'text'", doc.result().id());
             t = new Tuple(doc.result().id(), "text");
         } else {
-          stillMissing = true;
-          log.error("Could not find the data type for the field {}", doc.result().id());
+          missing.add(doc.result().id());
         }
       }
       if (t != null) results.add(t);
     }
-    if (stillMissing) throw new DataTypeNotFoundException();
+    if (!missing.isEmpty()) throw new DataTypeNotFoundException(missing, results);
     return results;
   }
 }

--- a/common/src/main/java/gov/nasa/pds/registry/common/connection/es/GetRespImpl.java
+++ b/common/src/main/java/gov/nasa/pds/registry/common/connection/es/GetRespImpl.java
@@ -132,10 +132,10 @@ class GetRespImpl implements Response.Get {
   @Override
   public List<Tuple> dataTypes() throws IOException, DataTypeNotFoundException {
     List<Tuple> dtInfo = new ArrayList<Tuple>();
+    List<String> missing = new ArrayList<String>();
     GetDataTypesResponseParser parser = new GetDataTypesResponseParser();
     List<GetDataTypesResponseParser.Record> records = parser.parse(this.response.getEntity());
     // Process response (list of fields)
-    boolean missing = false;
     for (GetDataTypesResponseParser.Record rec : records) {
       if (rec.found) {
         dtInfo.add(new Tuple(rec.id, rec.esDataType));
@@ -152,13 +152,12 @@ class GetRespImpl implements Response.Get {
           log.warn("Could not find datatype for field " + rec.id + ". Will use 'keyword'");
           dtInfo.add(new Tuple(rec.id, "keyword"));
         } else {
-          log.error("Could not find datatype for field " + rec.id);
-          missing = true;
+          missing.add(rec.id);
         }
       }
     }
-    if (missing == true)
-      throw new DataTypeNotFoundException();
+    if (!missing.isEmpty())
+      throw new DataTypeNotFoundException(missing, dtInfo);
 
     return dtInfo;
   }

--- a/common/src/main/java/gov/nasa/pds/registry/common/dd/LddException.java
+++ b/common/src/main/java/gov/nasa/pds/registry/common/dd/LddException.java
@@ -1,0 +1,26 @@
+package gov.nasa.pds.registry.common.dd;
+
+/**
+ * Thrown when a Local Data Dictionary (LDD) cannot be downloaded or loaded
+ * into the registry data dictionary index.
+ */
+@SuppressWarnings("serial")
+public class LddException extends Exception {
+
+  /**
+   * Constructor
+   * @param message description of the failure
+   */
+  public LddException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructor
+   * @param message description of the failure
+   * @param cause the underlying exception
+   */
+  public LddException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/common/src/main/java/gov/nasa/pds/registry/common/es/dao/dd/DataTypeNotFoundException.java
+++ b/common/src/main/java/gov/nasa/pds/registry/common/es/dao/dd/DataTypeNotFoundException.java
@@ -1,5 +1,11 @@
 package gov.nasa.pds.registry.common.es.dao.dd;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import gov.nasa.pds.registry.common.util.Tuple;
+
 /**
  *  Throw this exception when the data type for a new registry field 
  *  is not found in the data dictionary and Elasticsearch schema 
@@ -12,15 +18,26 @@ public class DataTypeNotFoundException extends Exception
 {
     private static final String LINK 
         = "See 'https://nasa-pds.github.io/pds-registry-app/operate/common-ops.html#Load' for more information.";
-    
-    /**
-     * Constructor
-     */
+
+    private final List<String> missingFields;
+    private final List<Tuple> foundTypes;
+
     public DataTypeNotFoundException()
     {
         super("Could not find datatype(s). " + LINK);
+        this.missingFields = Collections.emptyList();
+        this.foundTypes = Collections.emptyList();
     }
-    
+
+    public DataTypeNotFoundException(Collection<String> missingFields, List<Tuple> foundTypes)
+    {
+        super("Could not find datatype(s). " + LINK);
+        this.missingFields = Collections.unmodifiableList(List.copyOf(missingFields));
+        this.foundTypes = foundTypes != null
+            ? Collections.unmodifiableList(List.copyOf(foundTypes))
+            : Collections.emptyList();
+    }
+
     /**
      * Constructor
      * @param fieldName Elasticsearch field name
@@ -28,5 +45,17 @@ public class DataTypeNotFoundException extends Exception
     public DataTypeNotFoundException(String fieldName)
     {
         super("Could not find datatype for field '" + fieldName + "'. " + LINK);
+        this.missingFields = Collections.singletonList(fieldName);
+        this.foundTypes = Collections.emptyList();
+    }
+
+    public List<String> getMissingFields()
+    {
+        return missingFields;
+    }
+
+    public List<Tuple> getFoundTypes()
+    {
+        return foundTypes;
     }
 }

--- a/common/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
+++ b/common/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
@@ -2,6 +2,8 @@ package gov.nasa.pds.registry.common.es.service;
 
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -19,6 +21,7 @@ import gov.nasa.pds.registry.common.es.dao.dd.DataDictionaryDao;
 import gov.nasa.pds.registry.common.ConnectionFactory;
 import gov.nasa.pds.registry.common.es.dao.schema.SchemaDao;
 import gov.nasa.pds.registry.common.es.dao.dd.LddVersions;
+import gov.nasa.pds.registry.common.meta.OpsFields;
 
 
 /**
@@ -85,11 +88,32 @@ public class SchemaUpdater
             }
         }
         
-        // Update schema
+        // Update schema: resolve ops: fields from built-in map, all others from the -dd index
         if(fields != null && !fields.isEmpty())
         {
-            List<Tuple> newFields = ddDao.getDataTypes(fields);
-            if(newFields != null)
+            List<Tuple> newFields = new ArrayList<>();
+            Set<String> ddFields = new HashSet<>();
+            for(String field : fields)
+            {
+                String opsType = OpsFields.FIELD_TYPES.get(field);
+                if(opsType != null)
+                {
+                    newFields.add(new Tuple(field, opsType));
+                }
+                else
+                {
+                    ddFields.add(field);
+                }
+            }
+            if(!ddFields.isEmpty())
+            {
+                List<Tuple> ddTypes = ddDao.getDataTypes(ddFields);
+                if(ddTypes != null)
+                {
+                    newFields.addAll(ddTypes);
+                }
+            }
+            if(!newFields.isEmpty())
             {
                 schemaDao.updateSchema(newFields);
                 log.debug("Updated " + newFields.size() + " fields in OpenSearch mapping for index " + this.index);

--- a/common/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
+++ b/common/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import gov.nasa.pds.registry.common.dd.LddException;
 import gov.nasa.pds.registry.common.dd.LddUtils;
 import gov.nasa.pds.registry.common.util.ExceptionUtils;
 import gov.nasa.pds.registry.common.util.file.FileDownloader;
@@ -38,7 +39,12 @@ public class SchemaUpdater
     private SchemaDao schemaDao;
     
     final private String index;
-    
+    private boolean forceLoad = false;
+
+    public void setForceLoad(boolean forceLoad) {
+        this.forceLoad = forceLoad;
+    }
+
     /**
      * Constructor
      * @param cfg Registry (Elasticsearch) configuration
@@ -80,6 +86,10 @@ public class SchemaUpdater
                 try
                 {
                     updateLdd(uri, prefix);
+                }
+                catch(LddException ex)
+                {
+                    throw ex;
                 }
                 catch(Exception ex)
                 {
@@ -163,7 +173,13 @@ public class SchemaUpdater
             log.error(ExceptionUtils.getMessage(ex));
             if(lddInfo.isEmpty())
             {
-                log.warn("Will use 'keyword' data type.");
+                if(!forceLoad)
+                {
+                    throw new LddException("No previously loaded LDD found for namespace '"
+                        + prefix + "'. Cannot load products with fields from this namespace.");
+                }
+                log.warn("Force mode: no LDD found for namespace '" + prefix
+                    + "'. Fields from this namespace will not be indexed.");
                 return;
             }
             else

--- a/common/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
+++ b/common/src/main/java/gov/nasa/pds/registry/common/es/service/SchemaUpdater.java
@@ -19,6 +19,7 @@ import gov.nasa.pds.registry.common.util.file.FileDownloader;
 import gov.nasa.pds.registry.common.util.Tuple;
 
 import gov.nasa.pds.registry.common.es.dao.dd.DataDictionaryDao;
+import gov.nasa.pds.registry.common.es.dao.dd.DataTypeNotFoundException;
 import gov.nasa.pds.registry.common.ConnectionFactory;
 import gov.nasa.pds.registry.common.es.dao.schema.SchemaDao;
 import gov.nasa.pds.registry.common.es.dao.dd.LddVersions;
@@ -117,10 +118,29 @@ public class SchemaUpdater
             }
             if(!ddFields.isEmpty())
             {
-                List<Tuple> ddTypes = ddDao.getDataTypes(ddFields);
-                if(ddTypes != null)
+                try
                 {
-                    newFields.addAll(ddTypes);
+                    List<Tuple> ddTypes = ddDao.getDataTypes(ddFields);
+                    if(ddTypes != null)
+                    {
+                        newFields.addAll(ddTypes);
+                    }
+                }
+                catch(DataTypeNotFoundException ex)
+                {
+                    if(!forceLoad)
+                    {
+                        for(String f : ex.getMissingFields())
+                        {
+                            log.error("Could not find the data type for the field {}", f);
+                        }
+                        throw ex;
+                    }
+                    log.warn("Force mode: could not find data types for fields {} - these fields will not be indexed or searchable. Product will still be ingested.", ex.getMissingFields());
+                    if(!ex.getFoundTypes().isEmpty())
+                    {
+                        newFields.addAll(ex.getFoundTypes());
+                    }
                 }
             }
             if(!newFields.isEmpty())

--- a/common/src/main/java/gov/nasa/pds/registry/common/meta/OpsFields.java
+++ b/common/src/main/java/gov/nasa/pds/registry/common/meta/OpsFields.java
@@ -1,0 +1,36 @@
+package gov.nasa.pds.registry.common.meta;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Canonical ES type mapping for all ops: namespace fields. These are Harvest-internal operational
+ * fields whose types are defined here rather than in the registry-dd index.
+ */
+public class OpsFields {
+  public static final Map<String, String> FIELD_TYPES;
+
+  static {
+    Map<String, String> map = new HashMap<>();
+    map.put("ops:Harvest_Info/ops:node_name", "keyword");
+    map.put("ops:Harvest_Info/ops:harvest_date_time", "date");
+    map.put("ops:Harvest_Info/ops:harvest_version", "keyword");
+    map.put("ops:Tracking_Meta/ops:archive_status", "keyword");
+    map.put("ops:Provenance/ops:superseded_by", "keyword");
+    map.put("ops:Label_File_Info/ops:creation_date_time", "date");
+    map.put("ops:Label_File_Info/ops:file_ref", "keyword");
+    map.put("ops:Label_File_Info/ops:file_name", "keyword");
+    map.put("ops:Label_File_Info/ops:file_size", "long");
+    map.put("ops:Label_File_Info/ops:md5_checksum", "keyword");
+    map.put("ops:Label_File_Info/ops:blob", "binary");
+    map.put("ops:Label_File_Info/ops:json_blob", "binary");
+    map.put("ops:Data_File_Info/ops:creation_date_time", "date");
+    map.put("ops:Data_File_Info/ops:file_ref", "keyword");
+    map.put("ops:Data_File_Info/ops:file_name", "keyword");
+    map.put("ops:Data_File_Info/ops:file_size", "long");
+    map.put("ops:Data_File_Info/ops:md5_checksum", "keyword");
+    map.put("ops:Data_File_Info/ops:mime_type", "keyword");
+    FIELD_TYPES = Collections.unmodifiableMap(map);
+  }
+}

--- a/harvest/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
+++ b/harvest/src/main/java/gov/nasa/pds/harvest/HarvestCli.java
@@ -118,6 +118,8 @@ public class HarvestCli
         System.out.println("  -l <file>             Log file. Default is /tmp/harvest/harvest.log");
         System.out.println("  -v <level>            Logger verbosity: DEBUG, INFO (default), WARNING, ERROR");
         System.out.println("  -O, --overwrite       Overwrite registered products");
+        System.out.println("  -f, --force           Force load products even when namespace schema or attribute");
+        System.out.println("                        type cannot be resolved. Affected fields will not be indexed.");
         System.out.println("  -a, --archive-status  Set the archive status for all products defaulting to staged");
         for (String name : new ArchiveStatus().statusNames) {
           System.out.println("     " + name);
@@ -207,7 +209,10 @@ public class HarvestCli
         
         bld = Option.builder("O").longOpt("overwrite");
         options.addOption(bld.build());
-        
+
+        bld = Option.builder("f").longOpt("force");
+        options.addOption(bld.build());
+
         bld = Option.builder("a").longOpt("archive-status").hasArg().argName("archive_status");
         options.addOption(bld.build());
     }

--- a/harvest/src/main/java/gov/nasa/pds/harvest/cmd/HarvestCmd.java
+++ b/harvest/src/main/java/gov/nasa/pds/harvest/cmd/HarvestCmd.java
@@ -148,7 +148,8 @@ public class HarvestCmd implements CliCommand
         initWriterManager(cmdLine);
         
         boolean overwriteFlag = cmdLine.hasOption("overwrite");
-        
+        boolean forceFlag = cmdLine.hasOption("force");
+
         if (!Version.instance().checkVersion(ConfigManager.exchangeRegistry(cfg.getRegistry()),
             Arrays.asList(
                 gov.nasa.pds.registry.common.Version.instance(),
@@ -156,7 +157,7 @@ public class HarvestCmd implements CliCommand
           throw new ProviderException("Exiting without executing command because version is too old.");
         }
         // Registry manager
-        RegistryManager.init(ConfigManager.exchangeRegistry(cfg.getRegistry()), overwriteFlag);
+        RegistryManager.init(ConfigManager.exchangeRegistry(cfg.getRegistry()), overwriteFlag, forceFlag);
         log.info("Connecting to Elasticsearch");
         RegistryManager.getInstance().getFieldNameCache().update();
         

--- a/harvest/src/main/java/gov/nasa/pds/harvest/dao/RegistryManager.java
+++ b/harvest/src/main/java/gov/nasa/pds/harvest/dao/RegistryManager.java
@@ -28,6 +28,7 @@ public class RegistryManager
     
     private ConnectionFactory conFact;
     private boolean overwriteFlag;
+    private boolean forceLoad;
     
     private RestClient client;
 
@@ -48,10 +49,11 @@ public class RegistryManager
      * @param cfg Registry (Elasticsearch) configuration parameters.
      * @throws Exception Generic exception
      */
-    private RegistryManager(ConnectionFactory conFact, boolean overwriteFlag) throws Exception
+    private RegistryManager(ConnectionFactory conFact, boolean overwriteFlag, boolean forceLoad) throws Exception
     {
         this.conFact = conFact;
         this.overwriteFlag = overwriteFlag;
+        this.forceLoad = forceLoad;
         this.counter = new Counter();
         Logger log = LogManager.getLogger(this.getClass());
         log.log(LogUtils.LEVEL_SUMMARY, "Connection: " + conFact);
@@ -76,10 +78,10 @@ public class RegistryManager
      * @param overwriteFlag overwrite registered products
      * @throws Exception Generic exception
      */
-    public static synchronized void init(ConnectionFactory conFact, boolean overwriteFlag) throws Exception
+    public static synchronized void init(ConnectionFactory conFact, boolean overwriteFlag, boolean forceLoad) throws Exception
     {
       if (instance == null) {
-        instance = new RegistryManager(conFact, overwriteFlag);
+        instance = new RegistryManager(conFact, overwriteFlag, forceLoad);
       }
     }
     
@@ -166,6 +168,7 @@ public class RegistryManager
     public MissingFieldsProcessor createMissingFieldsProcessor() throws Exception
     {
         SchemaUpdater su = new SchemaUpdater(conFact, ddDao, schemaDao);
+        su.setForceLoad(forceLoad);
         return new MissingFieldsProcessor(su, fieldNameCache);
     }
 

--- a/harvest/src/test/java/tt/es/TestRegistryDAO.java
+++ b/harvest/src/test/java/tt/es/TestRegistryDAO.java
@@ -19,7 +19,7 @@ public class TestRegistryDAO
     {
         ConnectionFactory conFact = null;//"app:/connections/direct/localhost.xml";
         
-        RegistryManager.init(conFact, true);
+        RegistryManager.init(conFact, true, false);
 
         try
         {

--- a/manager/src/main/resources/elastic/registry.json
+++ b/manager/src/main/resources/elastic/registry.json
@@ -40,6 +40,7 @@
 
             "ops:Harvest_Info.ops:node_name": { "type": "keyword" },
             "ops:Harvest_Info.ops:harvest_date_time": { "type": "date" },
+            "ops:Harvest_Info.ops:harvest_version": { "type": "keyword" },
 
             "ops:Label_File_Info.ops:creation_date_time": { "type": "date" },
             "ops:Label_File_Info.ops:file_ref": { "type": "keyword" },


### PR DESCRIPTION
## 🗒️ Summary

This PR bundles three related fixes to `SchemaUpdater` and Harvest CLI:

### 1. Resolve `ops:` field types from built-in map; add missing `harvest_version` to schema (fixes #68)

Adds `OpsFields.java` with a canonical field→ES type map for all `ops:` namespace fields and updates `SchemaUpdater.updateSchema()` to resolve `ops:` fields from that map instead of the `-dd` index. Also adds the missing `ops:Harvest_Info.ops:harvest_version` field to `manager/registry.json` so new registries include it from initialization.

`ops:` fields are Harvest-internal operational fields with fixed, known ES types that are never stored in the `registry-dd` index. Sending them through `DataDictionaryDao.getDataTypes()` causes `DataTypeNotFoundException` for any field absent from an existing registry schema.

### 2. Fail product loading when LDD namespace cannot be resolved; add `-f/--force` flag (refs #65, #66)

When an LDD cannot be downloaded and no previously cached version exists in the data dictionary index, `SchemaUpdater` now throws `LddException` instead of silently falling back to `keyword` data type. This causes the product to fail loading with a clear ERROR message (`failedFileCount++`).

The new `-f / --force` flag opts in to lenient behavior: the product still loads but fields from the unresolvable namespace are omitted from the schema and not indexed. Keyword is **never** used as a fallback under any circumstances.

Also introduces `LddException` into `registry-loader/common` (ported from `registry-common`) so `SchemaUpdater` can signal namespace-level LDD failures as a distinct, catchable type.

### 3. Fix `--force` mode silently discarding found field types on partial `DataTypeNotFoundException` (fixes #75)

When `getDataTypes()` batches a set of new fields in a single MGET request and only *some* are missing from the `-dd` index, it threw `DataTypeNotFoundException` — but the exception carried no payload, so all *found* field types for the other fields in the same batch were silently discarded. In force mode, this meant even resolvable fields got no schema mapping update.

**Changes:**

| File | What changed |
|------|-------------|
| `DataTypeNotFoundException.java` | Added `missingFields: List<String>` and `foundTypes: List<Tuple>` fields; new `(Collection<String>, List<Tuple>)` constructor; `getMissingFields()` / `getFoundTypes()` accessors |
| `GetRespImpl.java` | Changed `boolean missing` flag → `List<String> missing`; throw site now passes accumulated found types to exception |
| `MGetRespWrap.java` | Same pattern: `boolean stillMissing` → `ArrayList<String> missing`; passes results to exception |
| `SchemaUpdater.java` | Added `DataTypeNotFoundException` import; wrapped `ddDao.getDataTypes()` in try-catch — in non-force mode logs each missing field and rethrows; in force mode logs a warning and recovers found types into the schema update |

### 🤖 AI Assistance Disclosure
- [ ] No AI assistance used
- [ ] AI used for light assistance (e.g., suggestions, refactoring, documentation help, minor edits)
- [ ] AI used for moderate content generation (AI generated some code or logic, but the developer authored or heavily revised the majority)
- [x] AI generated substantial portions of this code

Estimated % of code influenced by AI: 90%

## ⚙️ Test Data and/or Report

Schema fix (`registry.json`) verified against the field definition in `Metadata.java`. `OpsFields`/`SchemaUpdater` change is defensive and consistent with the fix in `registry-common`. `--force` flag wired through CLI → `RegistryManager` → `SchemaUpdater.setForceLoad()`. All 4 modules compile cleanly.

## ♻️ Related Issues

- Fixes #68
- Refs #65
- Refs #66
- Fixes #75
- Sister PRs:
  * https://github.com/NASA-PDS/harvest/pull/321
  * https://github.com/NASA-PDS/registry-common/pull/278
  * https://github.com/NASA-PDS/registry-common/pull/284
  * https://github.com/NASA-PDS/registry-mgr/pull/184

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.
- [ ] **Issue Traceability:** The PR is linked to a valid GitHub Issue
- [ ] **PR Title:** The PR title is "user-friendly" clearly identifying what is being fixed or the new feature being added, that if you saw it in the Release Notes for a tool, you would be able to get the gist of what was done.

### Security & Quality
- [ ] **SonarCloud:** Confirmed no new High or Critical security findings.
- [ ] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [ ] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Maintenance
- [ ] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).